### PR TITLE
/v4/characters/ -> /v5/characters/

### DIFF
--- a/app/Config/Ccp/Esi/Config.php
+++ b/app/Config/Ccp/Esi/Config.php
@@ -38,7 +38,7 @@ class Config extends AbstractConfig {
             ]
         ],
         'characters' => [
-            'GET' => '/v4/characters/{x}/',
+            'GET' => '/v5/characters/{x}/',
             'affiliation' => [
                 'POST' => '/v1/characters/affiliation/'
             ],


### PR DESCRIPTION
/v4/characters/ route was removed by cpp a month ago and this broke login in pathfinder
https://forums.eveonline.com/t/esi-v4-character-route-removed-please-update-to-v5/334374